### PR TITLE
Add url host check in external url handling

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -309,12 +309,6 @@ extension Session: WKNavigationDelegate {
         }
 
         var policy: WKNavigationActionPolicy {
-//            print("==============")
-//            print("url: \(String(describing: url))")
-//            print("link activated? \(navigationType == .linkActivated)")
-//            print("main frame? \(isMainFrameNavigation)")
-//            print("other? \(navigationType == .other)")
-//            print("same host? \(isSameHost(url))")
             return navigationType == .linkActivated || isMainFrameOutsideApp ? .cancel : .allow
         }
 


### PR DESCRIPTION
This fixes a bug where opening an Angular path (i.e. workflows) was making Turbolinks think it was an external url, thus it was opening in Safari.