### PR TITLE
Add delegate method for good server response

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -8,6 +8,7 @@ public protocol SessionDelegate: class {
     func sessionDidLoadWebView(_ session: Session)
     func sessionDidStartRequest(_ session: Session)
     func sessionDidFinishRequest(_ session: Session)
+    func sessionDidReceiveGoodResponse(_ session: Session)
 }
 
 public extension SessionDelegate {
@@ -178,6 +179,7 @@ extension Session: VisitDelegate {
     }
 
     func visitWillLoadResponse(_ visit: Visit) {
+        delegate?.sessionDidReceiveGoodResponse(self)
         visit.visitable.updateVisitableScreenshot()
         visit.visitable.showVisitableScreenshot()
     }

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -193,6 +193,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
         if let httpResponse = navigationResponse.response as? HTTPURLResponse {
             if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
+                self.delegate?.visitWillLoadResponse(self)
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)


### PR DESCRIPTION
Previously we only were notified when the request failed. Adding this delegate method allows us to know when the server request succeeds and take any necessary actions. This was added specifically to help with the login flow. When the server responds successfully, we fade out the launch overlay. 