### PR TITLE
Fix long cold boot

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WebKit
 
-public protocol SessionDelegate: class {
+public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisitToURL URL: URL, withAction action: Action)
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, withError error: NSError)
     func session(_ session: Session, openExternalURL URL: URL)
@@ -17,7 +17,7 @@ public extension SessionDelegate {
     }
 
     func session(_ session: Session, openExternalURL URL: Foundation.URL) {
-        UIApplication.shared.openURL(URL)
+        UIApplication.shared.open(URL)
     }
 
     func sessionDidStartRequest(_ session: Session) {

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -1,6 +1,6 @@
 import WebKit
 
-protocol VisitDelegate: class {
+protocol VisitDelegate: AnyObject {
     func visitDidInitializeWebView(_ visit: Visit)
 
     func visitWillStart(_ visit: Visit)

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -187,7 +187,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
         if navigationAction.navigationType == .linkActivated {
             decisionHandler(.cancel)
             if let URL = navigationAction.request.url {
-                UIApplication.shared.openURL(URL)
+                UIApplication.shared.open(URL)
             }
         } else {
             decisionHandler(.allow)

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -140,6 +140,7 @@ class Visit: NSObject {
 
 class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     fileprivate var navigation: WKNavigation?
+    fileprivate var responseReceived = false
 
     override fileprivate func startVisit() {
         webView.navigationDelegate = self
@@ -186,9 +187,15 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
 
     fileprivate func checkForRequestResponse(_ navigation: WKNavigation) {
         if navigation === self.navigation && !responseReceived {
-            cancel()
-            start()
+            restartRequest()
         }
+    }
+
+    fileprivate func restartRequest() {
+        cancel()
+        state = .initialized
+        requestStarted = false
+        start()
     }
 
     // MARK: WKNavigationDelegate

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -207,6 +207,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
             self.checkForRequestResponse(navigation)
         }
     }
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if navigation === self.navigation {
             finishRequest()

--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -1,14 +1,14 @@
 import UIKit
 import WebKit
 
-public protocol VisitableDelegate: class {
+public protocol VisitableDelegate: AnyObject {
     func visitableViewWillAppear(_ visitable: Visitable)
     func visitableViewDidAppear(_ visitable: Visitable)
     func visitableDidRequestReload(_ visitable: Visitable)
     func visitableDidRequestRefresh(_ visitable: Visitable)
 }
 
-public protocol Visitable: class {
+public protocol Visitable: AnyObject {
     var visitableDelegate: VisitableDelegate? { get set } 
     var visitableView: VisitableView! { get }
     var visitableURL: URL! { get }

--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -89,7 +89,7 @@ open class VisitableView: UIView {
     // MARK: Activity Indicator
 
     open lazy var activityIndicatorView: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .white)
+        let view = UIActivityIndicatorView(style: .medium)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.color = UIColor.gray
         view.hidesWhenStopped = true

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -1,16 +1,16 @@
 import WebKit
 
-protocol WebViewDelegate: class {
+protocol WebViewDelegate: AnyObject {
     func webView(_ webView: WebView, didProposeVisitToLocation location: URL, withAction action: Action)
     func webViewDidInvalidatePage(_ webView: WebView)
     func webView(_ webView: WebView, didFailJavaScriptEvaluationWithError error: NSError)
 }
 
-protocol WebViewPageLoadDelegate: class {
+protocol WebViewPageLoadDelegate: AnyObject {
     func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String)
 }
 
-protocol WebViewVisitDelegate: class {
+protocol WebViewVisitDelegate: AnyObject {
     func webView(_ webView: WebView, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool)
     func webView(_ webView: WebView, didStartRequestForVisitWithIdentifier identifier: String)
     func webView(_ webView: WebView, didCompleteRequestForVisitWithIdentifier identifier: String)


### PR DESCRIPTION
There seems to be a bug with WKWebView where sometimes there will be a substantial delay when attempting to load a URL (https://developer.apple.com/forums/thread/656106). In Turbolinks, this will only happen during a `ColdBootVisit` where we are navigating to a webpage using the normal `URLRequest`. By and large this really only happens when the app first starts up so a user will see the blank blue screen for a long time before either then seeing dashboard or the login page. It also can happen if the session is still valid, but maybe the app has not been used in a while and Turbolinks somehow becomes uninitialized. It can also happen after trying to logout.

I've determined where in the navigational callbacks the delay happens and implemented a check after 3 seconds to see if we have received a response yet. If we have not, we cancel the page load and start it again. This hack has proven to work in reducing how frequently this bug affects page load times.